### PR TITLE
MergedStreamValidator should starts listing from start time on merged cl...

### DIFF
--- a/conduit-worker/src/main/java/com/inmobi/conduit/validator/MergedStreamValidator.java
+++ b/conduit-worker/src/main/java/com/inmobi/conduit/validator/MergedStreamValidator.java
@@ -65,8 +65,10 @@ public class MergedStreamValidator extends AbstractStreamValidator {
     Map<String, FileStatus> mergeStreamFileListing = new TreeMap<String, FileStatus>();
     Path mergePath = new Path(mergeCluster.getFinalDestDirRoot(), streamName);
     FileSystem mergedFs = FileSystem.get(mergeCluster.getHadoopConf());
+    Path mergeStartPath = new Path(mergePath,
+        Cluster.getDateAsYYYYMMDDHHMNPath(startTime));
     ParallelRecursiveListing mergeParallelListing =
-        new ParallelRecursiveListing(numThreads, null, null);
+        new ParallelRecursiveListing(numThreads, mergeStartPath, null);
     List<FileStatus> mergeStreamFileStatuses = 
         mergeParallelListing.getListing(mergePath, mergedFs, true);
 


### PR DESCRIPTION
Currently, MergedStreamValidator is listing whole stream on the merged cluster. We can optimize little bit by starts listing from a given start time. 
