### PR TITLE
Load latency summary details asynchronously

### DIFF
--- a/conduit-visualization/src/main/java/com/inmobi/conduit/visualization/client/Visualization.java
+++ b/conduit-visualization/src/main/java/com/inmobi/conduit/visualization/client/Visualization.java
@@ -42,8 +42,15 @@ public class Visualization implements EntryPoint, ClickHandler {
   private Map<String, String> clientConfig;
   private int rolledUpTillDays;
   DataServiceWrapper serviceInstance = new DataServiceWrapper();
+  private static Visualization instance;
+
+  public void init() {
+    instance = this;
+  }
 
   public void onModuleLoad() {
+    init();
+    exportSummaryQueryFunction();
     buildStreamsAndClustersList();
   }
 
@@ -628,4 +635,18 @@ public class Visualization implements EntryPoint, ClickHandler {
     hdfsSla, localSla, mergeSla, mirrorSla, percentileForSla,
     percentageForLoss, percentageForWarn, lossWarnThresholdDiff,isDevMode);
   }-*/;
+
+  public static native void exportSummaryQueryFunction()/*-{
+    $wnd.fireLatencyQuery = @com.inmobi.conduit.visualization.client.Visualization::fireLatencyQuery(*);
+  }-*/;
+
+  public static void fireLatencyQuery(String stTime, String edTime,
+                                      String selectedCluster, String selectedStream) {
+    System.out.println("Query start:"+stTime+", Query end:"+edTime+", " +
+        "Query stream:"+selectedCluster+",Query cluster:"+selectedStream);
+
+    String clientJson = ClientDataHelper.getInstance()
+        .setGraphDataRequest(stTime, edTime, selectedStream, selectedCluster);
+    instance.getTierLatencyData(clientJson);
+  }
 }

--- a/conduit-visualization/src/main/java/com/inmobi/conduit/visualization/public/common.js
+++ b/conduit-visualization/src/main/java/com/inmobi/conduit/visualization/public/common.js
@@ -119,6 +119,10 @@ function saveHistory(changeParams, streamName, clusterName, tier,
     }
     if (!isReloadComplete) {
       setCountLatencyView(History.getState().data.selectedTab);
+      if (!isCountView) {
+      	fireLatencyQuery(qstart, qend, History.getState().data.qcluster,
+      	History.getState().data.qstream);
+      }
       highlightTab();
       if (qView == 1) {
         highlightTierButton(History.getState().data.qtier);
@@ -238,6 +242,10 @@ function clearAllAndAddLoadSymbol(viewId) {
 
 function tabSelected(selectedTabID) {
   setCountLatencyView(selectedTabID);
+  if (!isCountView) {
+   	fireLatencyQuery(qstart, qend, History.getState().data.qcluster,
+   	History.getState().data.qstream);
+  }
   highlightTab();
   clearAllAndAddLoadSymbol();
   saveHistoryAndReload(qStream, qCluster, 'all', selectedTabID);

--- a/conduit-visualization/src/main/java/com/inmobi/conduit/visualization/public/summary.js
+++ b/conduit-visualization/src/main/java/com/inmobi/conduit/visualization/public/summary.js
@@ -9,7 +9,7 @@ function setTierLatencyValues(pLatency, aLatency, cLatency, hLatency, lLatency,
   tierLatencyMap["local"] = lLatency;
   tierLatencyMap["merge"] = meLatency;
   tierLatencyMap["mirror"] = miLatency;
-  //loadLatencySummary();
+  loadLatencySummary();
 }
 
 function addSummaryBox(treeList) {


### PR DESCRIPTION
For Latency view in Topology graph, summary time  does not change even though you drill down to different tier/cluster/stream within the graph. So to have correct summary time for drill down graph, launch async query to get summary details